### PR TITLE
Fixed #2 and bumped version

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -5,12 +5,19 @@ var express = require('express');
 var webpack = require('webpack');
 var webpackDevMiddleware = require('webpack-dev-middleware');
 var webpackHotMiddleware = require('webpack-hot-middleware');
+var omit = require('lodash.omit');
 
 module.exports = function(webpackConfig, serverOpts) {
   var app = express();
 
   function useConfig(config) {
-    var compiler = webpack(config);
+    var omittedKeys = [
+      'devMiddleware',
+      'hotMiddleware'
+    ];
+    var properWebpackConfig = omit(config, omittedKeys);
+    var compiler = webpack(properWebpackConfig);
+
     app.use(webpackDevMiddleware(compiler, config.devMiddleware));
     app.use(webpackHotMiddleware(compiler, config.hotMiddleware));
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-httpolyglot-server",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Using httpolyglot to serve http/https over the same port for Webpack development server",
   "main": "lib/server.js",
   "files": [
@@ -16,6 +16,7 @@
   "dependencies": {
     "express": "^4.14.0",
     "httpolyglot": "^0.1.1",
+    "lodash.omit": "^4.5.0",
     "webpack-dev-middleware": "^1.6.1",
     "webpack-hot-middleware": "^2.12.2",
     "yargs": "^5.0.0"


### PR DESCRIPTION
- added `lodash.omit` to omit `devMiddleware` and `hotMiddleware`
- no effect on webpack1
